### PR TITLE
[VarDumper] add draw boolean value with different styles in cli

### DIFF
--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * added the stamps of a message after it is dispatched in `TraceableMessageBus` and `MessengerDataCollector` collected data
  * added `UuidCaster`
  * made all casters final
+ * draw boolean in different styles
 
 4.3.0
 -----

--- a/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
+++ b/src/Symfony/Component/VarDumper/Dumper/CliDumper.php
@@ -31,6 +31,8 @@ class CliDumper extends AbstractDumper
         'default' => '38;5;208',
         'num' => '1;38;5;38',
         'const' => '1;38;5;208',
+        'true' => '1;38;5;40',
+        'false' => '1;38;5;213',
         'str' => '1;38;5;113',
         'note' => '38;5;38',
         'ref' => '38;5;247',
@@ -167,6 +169,7 @@ class CliDumper extends AbstractDumper
 
             case 'boolean':
                 $value = $value ? 'true' : 'false';
+                $style = $value;
                 break;
 
             default:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.4
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| Tickets       | -
| License       | MIT
| Doc PR        | -

`dump` function, draw `bool` and `false`, with same style, I think, will better, if it have different colors.

How it looks before merge:
<img width="152" alt="Screenshot 2019-10-08 10 33 26" src="https://user-images.githubusercontent.com/2186303/66380248-54a69100-e9b7-11e9-8347-166f060bd544.png">


And after: 
<img width="152" alt="Screenshot 2019-10-08 10 34 54" src="https://user-images.githubusercontent.com/2186303/66380256-583a1800-e9b7-11e9-80c2-04ddca2f2ffd.png">
